### PR TITLE
Adds accessibility identifier, and UIAccessibility trait

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 				3B21D4862785F3EF0009DE6A /* PBXTargetDependency */,
 			);
 			name = LCLabelUITests;
+			packageProductDependencies = (
+			);
 			productName = LCLabelUITests;
 			productReference = 3B21D47F2785F3EF0009DE6A /* LCLabelUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";

--- a/DemoApp/LCLabelUITests/LCLabelHitTests.swift
+++ b/DemoApp/LCLabelUITests/LCLabelHitTests.swift
@@ -18,6 +18,11 @@ final class LCLabelHitTests: XCTestCase {
     app = XCUIApplication()
     app.launchArguments = [""]
     app.launch()
+
+    XCTAssertEqual(
+      app.staticTexts.matching(.staticText, identifier: "lcllabel+1").firstMatch.identifier,
+      "lcllabel+1")
+
     let main = app.otherElements["main"]
     XCTAssertTrue(main.exists)
     XCTAssertTrue(main.staticTexts["translator"].exists)

--- a/Sources/LCLabel/LCLabel.swift
+++ b/Sources/LCLabel/LCLabel.swift
@@ -50,6 +50,16 @@ final public class LCLabel: UIView {
   }
 
   // MARK: - Variables
+
+  public override var accessibilityTraits: UIAccessibilityTraits {
+    get {
+      _accessibilityTraits
+    }
+    set {
+      _accessibilityTraits = newValue
+    }
+  }
+
   /// A LCLabel delegate that responses to link interactions within
   /// the view
   public weak var delegate: LCLabelDelegate?
@@ -126,6 +136,7 @@ final public class LCLabel: UIView {
         renderedStorage = nil
         isHidden = true
       }
+      accessibilityIdentifier = newValue?.string
       setupRenderStorage()
       refreshView()
     }
@@ -143,14 +154,16 @@ final public class LCLabel: UIView {
   }()
 
   private var currentlySelectedLink: URL?
+  private var _accessibilityTraits: UIAccessibilityTraits
 
   // MARK: - Life Cycle
 
-  public init() {
-    super.init(frame: .zero)
+  public convenience init() {
+    self.init(frame: .zero)
   }
 
   public override init(frame: CGRect) {
+    _accessibilityTraits = .staticText
     super.init(frame: frame)
   }
 


### PR DESCRIPTION
Adds accessibility identifier, and sets UIAccessibility trait to be .staticText. Thus allows us to basically call `app.staticTexts.matching(.staticText, identifier: "lcllabel+1")`